### PR TITLE
Downloading All Tree Data Functionality and Importing it to Google Sheets

### DIFF
--- a/src/app/treeTable/page.tsx
+++ b/src/app/treeTable/page.tsx
@@ -1,9 +1,25 @@
 "use client";
-import { Table, Thead, Tbody, Tr, Th, Td, Text, TableContainer, Box, Button, Image } from "@chakra-ui/react";
+import {
+  Table,
+  Flex,
+  Thead,
+  Tbody,
+  HStack,
+  Tr,
+  Th,
+  Td,
+  Text,
+  TableContainer,
+  Box,
+  Button,
+  Image,
+} from "@chakra-ui/react";
+import * as XLSX from "xlsx";
 import Navbar from "@/components/Navbar";
 import "./treetable.css";
 import { useState, useEffect } from "react";
 import { ITree } from "@/database/treeSchema";
+import { FileDown } from "lucide-react";
 export default function TreeTable() {
   const [trees, setTrees] = useState<ITree[]>([]);
   useEffect(() => {
@@ -39,12 +55,45 @@ export default function TreeTable() {
       setCurrentPage(pageNumber);
     }
   };
+
+  const downloadData = () => {
+    // retreive ALL volunteers data
+    const dataSheet = XLSX.utils.json_to_sheet(
+      trees.map((tree: ITree, index) => ({
+        Index: index,
+        "Tree Id": tree._id,
+        "Collector Name": tree.collectorName,
+        "Date Collected": new Date(tree.dateCollected).toLocaleDateString(),
+        "GPS Coordinates": Array.isArray(tree.gpsCoordinates) ? tree.gpsCoordinates.join(", ") : tree.gpsCoordinates,
+        "DBH (inches)": tree.dbh.toString(),
+        "Tree Canopy Breadth": tree.canopyBreadth.toString(),
+        Species: tree.species,
+        "Tree Quality": String(tree.treeQuality),
+        "Tree Condition": Array.isArray(tree.treeCondition) ? tree.treeCondition.join(", ") : tree.treeCondition,
+        "Additional Notes": tree.additionalNotes || "N/A",
+      })),
+    );
+
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, dataSheet, "Trees Table");
+    XLSX.writeFile(wb, "treesTable.xlsx");
+  };
   return (
     <Box width="100%" height="100%" p={{ base: "20px", md: "50px" }} display="flex" justifyContent="center">
       <Box w="90%" maxWidth="1137px">
-        <Text fontSize={["24px", "30px", "38px"]} color="#333" fontWeight="600" mb="30px">
-          Tree Inventory
-        </Text>
+        <Flex justifyContent={"space-between"}>
+          <Text fontSize={["24px", "30px", "38px"]} color="#333" fontWeight="600" mb="30px">
+            Tree Inventory
+          </Text>
+          <Button padding={4} bg="white" borderRadius="24px" variant="solid" right={0} onClick={downloadData}>
+            <HStack spacing={2}>
+              <Text color="#596334" fontWeight="600">
+                Export to Sheets
+              </Text>
+              <FileDown color="#596334" />
+            </HStack>
+          </Button>
+        </Flex>
         <TableContainer bg="white" borderRadius="10px">
           <Table className="tree-table">
             <Thead>


### PR DESCRIPTION
## Developer: Sophia Chang

Closes #67 

### Pull Request Summary

Added the "Export to Sheets" button in treeTable's page.tsx and implemented functionality where all tree data would be donwloaded into an xlsx format, allowing it to be imported onto Google Sheets.

### Modifications

Just the treeTable's page.tsx

### Testing Considerations

Tested the button download functionality and tested to make sure all data was uploaded onto Google Sheets.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

https://github.com/user-attachments/assets/ab8c691c-3d79-41bb-8196-1de374058ce2