### PR TITLE
Fixed table blank row extensions

### DIFF
--- a/src/app/messages/messages.module.css
+++ b/src/app/messages/messages.module.css
@@ -66,6 +66,7 @@
   margin-top: 10px;
   background: white;
   overflow: hidden;
+  min-height: 550px;
 }
 
 .tableHeader {

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -176,6 +176,12 @@ function Messages() {
                             </Td>
                           </Tr>
                         ))}
+                        {/* Used to create whitespace on the last  */}
+                        {Array.from({ length: 7 - currentMessages.length }).map((_, i) => (
+                          <tr key={`empty-${i}`} style={{ height: "55px" }}>
+                            <td colSpan={5} />
+                          </tr>
+                        ))}
                       </Tbody>
 
                       {/* Page Controls */}


### PR DESCRIPTION
## Developer: Emi Dinh

Closes #85 

### Pull Request Summary

Merging in the messages table format so that on the last page, it populates with blank rows to ensure a uniform design across the platform. 

### Modifications

messages/page.tsx
messages/messages.css.tsx

### Testing Considerations

Went to the last page and checked if it's inline with the other messages page

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="1205" alt="Screenshot 2025-05-11 at 12 01 02 AM" src="https://github.com/user-attachments/assets/08a5e6f0-cab7-4cc4-95be-ff903645ceef" />


