### PR TITLE
Added frontend protection for image type validation

### DIFF
--- a/src/app/newTreeForm/page.tsx
+++ b/src/app/newTreeForm/page.tsx
@@ -85,10 +85,26 @@ export default function TreeEntryForm() {
     treeIssues: [],
     fieldNotes: "",
   });
+
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setSelectedImage(file); // Save the file directly
+
+    // image type validation
+    const validTypes = ["image/jpeg", "image/png", "image/jpg", "image/webp"];
+    if (!validTypes.includes(file.type)) {
+      alert("Only image files (JPEG, PNG, WEBP) are allowed.");
+      return;
+    }
+
+    // file size limit
+    const maxSize = 5;
+    if (file.size > maxSize * 1024 * 1024) {
+      alert(`File size exceeds ${maxSize}MB limit.`);
+      return;
+    }
+
+    setSelectedImage(file);
   };
 
   const handleTreeType = (e: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## Developer: Emi Dinh

Closes #115 

### Pull Request Summary

Enforce phototypes for photo upload. Only jpg, jpeg, png, and webp are now uploadable. Limited photo sizes to 5 mb as well. 

### Modifications

newtreeform/page.tsx checks the file type prior to submitting. If the file is the wrong type then users will receive a notification. Checks size and limits to 5 MB. 

### Testing Considerations

Tried uploading different files but only png, jpg, and webp works. 

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
<img width="521" alt="Screenshot 2025-05-13 at 3 06 26 PM" src="https://github.com/user-attachments/assets/4aa34a63-07b7-45d8-b3c5-1a13062e49d0" />
<img width="503" alt="Screenshot 2025-05-13 at 3 06 38 PM" src="https://github.com/user-attachments/assets/167beef1-c33c-42e8-ae01-209bb489ddf9" />
<img width="550" alt="Screenshot 2025-05-13 at 3 06 55 PM" src="https://github.com/user-attachments/assets/97becfe1-e019-44e8-8d03-4df19af95d7b" />
<img width="509" alt="Screenshot 2025-05-13 at 3 07 24 PM" src="https://github.com/user-attachments/assets/db838800-4d1b-4ec3-8b31-c3b91cbac38e" />
<img width="462" alt="Screenshot 2025-05-13 at 3 08 24 PM" src="https://github.com/user-attachments/assets/0bd65c31-e521-4aa4-8bb4-b8093bbd6dfd" />


{put screenshots of your change, or even better a screencast displaying the functionality}
