### PR TITLE
101 messages mobile

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # create local copy of this file and rename to .env.local
 # make sure to add .env.local to .gitignore!!
-MONGO_URI={mongo-uri-here}
+# MONGO_URI={mongo-uri-here}
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_YW11c2luZy1zZWFzbmFpbC01OS5jbGVyay5hY2NvdW50cy5kZXYk
 NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL=/signupredirect

--- a/__tests__/CreateAnnouncement.test.tsx
+++ b/__tests__/CreateAnnouncement.test.tsx
@@ -7,6 +7,7 @@ import "@testing-library/jest-dom";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CreateAnnouncement from "@/app/createAnnouncement/page";
+import { act } from "react";
 
 jest.mock("@clerk/nextjs", () => ({
   ClerkProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -29,71 +30,94 @@ jest.mock("@clerk/nextjs", () => ({
   }),
 }));
 
+beforeAll(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve([{ name: "Test User", email: "test@example.com", role: "admin" }]),
+    }),
+  ) as jest.Mock;
+});
+
 describe("CreateAnnouncement", () => {
-  it("renders the form correctly", () => {
-    render(<CreateAnnouncement />);
+  it("renders the form correctly", async () => {
+    await act(async () => {
+      render(<CreateAnnouncement />);
+    });
 
     expect(screen.getByText("New Message")).toBeInTheDocument();
-    expect(screen.getByLabelText("Send to")).toBeInTheDocument();
+    expect(screen.getByText("Send to")).toBeInTheDocument();
     expect(screen.getByLabelText("Subject")).toBeInTheDocument();
     expect(screen.getByLabelText("Message")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Send/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Cancel/i })).toBeInTheDocument();
   });
 
   it("updates form fields when user types", async () => {
-    render(<CreateAnnouncement />);
+    await act(async () => {
+      render(<CreateAnnouncement />);
+    });
 
-    const recipientsInput = screen.getByPlaceholderText("Find recipients") as HTMLInputElement;
     const subjectInput = screen.getByPlaceholderText("Subject line here") as HTMLInputElement;
     const messageInput = screen.getByPlaceholderText("Type your message here...") as HTMLTextAreaElement;
 
-    await userEvent.type(recipientsInput, "testUser");
     await userEvent.type(subjectInput, "Meeting Update");
     await userEvent.type(messageInput, "Hello everyone, please note the meeting time change.");
 
-    expect(recipientsInput.value).toBe("testUser");
     expect(subjectInput.value).toBe("Meeting Update");
     expect(messageInput.value).toBe("Hello everyone, please note the meeting time change.");
   });
 
-  it("handles file selection correctly", () => {
-    render(<CreateAnnouncement />);
+  it("handles file selection correctly", async () => {
+    await act(async () => {
+      render(<CreateAnnouncement />);
+    });
 
-    const fileInput = screen.getByLabelText(/Add attachment/i);
+    const fileInput = screen.getByTestId("file-upload");
+
     const file = new File(["sample content"], "sample.txt", { type: "text/plain" });
 
     fireEvent.change(fileInput, { target: { files: [file] } });
 
-    // Check if the file name appears correctly
     const attachmentText = screen.getByText("sample.txt");
     expect(attachmentText).toBeInTheDocument();
   });
 
-  it("handles form submission correctly", () => {
+  it("submits form with correct data", async () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation();
 
-    // Render the component
-    render(<CreateAnnouncement />);
+    await act(async () => {
+      render(<CreateAnnouncement />);
+    });
 
-    const recipientsInput = screen.getByPlaceholderText(/Find recipients/i);
+    const sendToAllButton = screen.getByRole("button", { name: "Send to All" });
+    await act(async () => {
+      fireEvent.click(sendToAllButton);
+    });
+
     const subjectInput = screen.getByPlaceholderText(/Subject line here/i);
     const messageTextarea = screen.getByPlaceholderText(/Type your message here/i);
 
-    fireEvent.change(recipientsInput, { target: { value: "Test User" } });
-    fireEvent.change(subjectInput, { target: { value: "Test Subject" } });
-    fireEvent.change(messageTextarea, { target: { value: "Test Message" } });
+    await act(async () => {
+      fireEvent.change(subjectInput, { target: { value: "Test Subject" } });
+      fireEvent.change(messageTextarea, { target: { value: "Test Message" } });
+    });
 
-    // Simulate form submission
-    const submitButton = screen.getByRole("button", { name: /Send/i });
-    fireEvent.click(submitButton);
+    const submitButton = screen.getByRole("button", { name: /^Send$/ });
 
-    // Check if console.log was called with the correct form data
-    expect(logSpy).toHaveBeenCalledWith("Submitted Data: ", {
-      recipients: "Test User",
-      subject: "Test Subject",
-      message: "Test Message",
-      attachment: null,
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(logSpy).toHaveBeenCalledWith(
+        "Submitted Data: ",
+        expect.objectContaining({
+          subject: "Test Subject",
+          message: "Test Message",
+          attachment: null,
+        }),
+      );
     });
 
     logSpy.mockRestore();

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -3,7 +3,7 @@ import connectDB from "@/database/db";
 import User, { IUser } from "@/database/userSchema";
 
 // get all users
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   await connectDB();
 
   try {

--- a/src/app/createAnnouncement/announcement.module.css
+++ b/src/app/createAnnouncement/announcement.module.css
@@ -1,0 +1,23 @@
+
+
+.recipientSection {
+  width: 100%;
+}
+
+.buttonRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.checkboxContainer {
+  max-height: 150px;
+  overflow-y: auto;
+  border: 1px solid #ffffff;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}

--- a/src/app/createAnnouncement/announcement.module.css
+++ b/src/app/createAnnouncement/announcement.module.css
@@ -15,6 +15,8 @@
   max-height: 150px;
   overflow-y: auto;
   border: 1px solid #ffffff;
+  background: white;
+  border: 1px solid #ccc;
   border-radius: 0.5rem;
   padding: 1rem;
   display: flex;

--- a/src/app/createAnnouncement/page.tsx
+++ b/src/app/createAnnouncement/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useUser } from "@clerk/nextjs";
-
 import { useState, useEffect } from "react";
 import {
   Box,
@@ -11,23 +10,16 @@ import {
   Textarea,
   VStack,
   IconButton,
-  Image,
-  Text,
   HStack,
+  Text,
+  Checkbox,
 } from "@chakra-ui/react";
-import { AlignJustify } from "lucide-react";
-import { BrowserView, MobileView } from "react-device-detect";
 import { AttachmentIcon } from "@chakra-ui/icons";
 import { InputStyleAnnouncement } from "@/styles/CreateAnnouncementStyle";
+import styles from "./announcement.module.css";
 
 const CreateAnnouncement = () => {
   const { user } = useUser();
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
   type AnnouncementData = {
     recipients: string;
     subject: string;
@@ -41,6 +33,36 @@ const CreateAnnouncement = () => {
     message: "",
     attachment: null, // Make sure this is 'attachment'
   });
+
+  const [allUsers, setAllUsers] = useState<{ name: string; email: string; role: string }[]>([]);
+  const [selectedRecipients, setSelectedRecipients] = useState<string[]>([]);
+  const [activeGroup, setActiveGroup] = useState<"all" | "admin" | null>(null);
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const res = await fetch("/api/user");
+
+        if (!res.ok) {
+          const errorText = await res.text(); // get error message if available
+          throw new Error(`Failed to fetch users. Status: ${res.status}, Message: ${errorText}`);
+        }
+
+        const users = await res.json();
+        setAllUsers(users);
+      } catch (err) {
+        console.error("Failed to fetch users:", err);
+      }
+    };
+    fetchUsers();
+  }, []);
+
+  useEffect(() => {
+    setFormData((prev) => ({
+      ...prev,
+      recipients: selectedRecipients.join(","),
+    }));
+  }, [selectedRecipients]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -60,9 +82,14 @@ const CreateAnnouncement = () => {
   };
 
   const handleSubmit = async () => {
+    if (selectedRecipients.length === 0) {
+      console.error("Please select at least one recipient.");
+      return;
+    }
+
     try {
       const from = user?.fullName || "Unknown Sender";
-      const to = formData.recipients.split(",").map((r) => r.trim());
+      const to = selectedRecipients;
 
       const payload = {
         from,
@@ -91,210 +118,133 @@ const CreateAnnouncement = () => {
   };
 
   return (
-    <div>
-      {isClient ? (
-        <>
-          <BrowserView>
-            <Box
-              position="absolute"
-              width="100vw"
-              minHeight="100vh"
-              bg="#F4F1E8"
-              transform="translateX(-15rem)"
-              pl="15rem"
-              display="flex"
-              alignItems="center"
+    <Box
+      position="absolute"
+      width="100vw"
+      minHeight="100vh"
+      bg="#F4F1E8"
+      transform="translateX(-15rem)"
+      pl="15rem"
+      display="flex"
+      alignItems="center"
+    >
+      <VStack spacing={7} align="start" p="50px" py="50px" width="100%" maxW="900px" mx="auto">
+        <Box fontSize="3xl" fontWeight="bold">
+          New Message
+        </Box>
+        <FormControl className={styles.recipientSection}>
+          <FormLabel fontWeight="bold">Send to</FormLabel>
+
+          <div className={styles.buttonRow}>
+            <Button
+              bg={activeGroup === "all" ? "#e0efc4" : "white"}
+              color="#596435"
+              border={activeGroup === "all" ? "2px solid #596435" : "1px solid #ccc"}
+              _hover={{ bg: "#e0efc4" }}
+              onClick={() => {
+                setSelectedRecipients(allUsers.map((u) => u.email));
+                setActiveGroup("all");
+              }}
             >
-              <VStack spacing={7} align="start" p="50px" py="50px" width="100%" maxW="900px" mx="auto">
-                <Box fontSize="3xl" fontWeight="bold">
-                  New Message
-                </Box>
-                <FormControl>
-                  <FormLabel fontWeight="bold">Send to</FormLabel>
-                  <Input
-                    name="recipients"
-                    placeholder="Find recipients"
-                    _placeholder={{ color: "#596435" }}
-                    value={formData.recipients}
-                    onChange={handleChange}
-                    {...InputStyleAnnouncement}
-                  />
-                </FormControl>
-                <FormControl>
-                  <FormLabel fontWeight="bold">Subject</FormLabel>
-                  <Input
-                    name="subject"
-                    placeholder="Subject line here"
-                    _placeholder={{ color: "#596435" }}
-                    value={formData.subject}
-                    onChange={handleChange}
-                    {...InputStyleAnnouncement}
-                  />
-                </FormControl>
-                <FormControl position="relative">
-                  <FormLabel fontWeight="bold">Message</FormLabel>
-                  <Textarea
-                    name="message"
-                    placeholder="Type your message here..."
-                    _placeholder={{ color: "#596435" }}
-                    value={formData.message}
-                    onChange={handleChange}
-                    {...InputStyleAnnouncement}
-                    h="250px"
-                    pr="40px" // Space for icon
-                  />
-                  <Box position="absolute" top="35px" right="15px" display="flex" alignItems="center">
-                    <label htmlFor="file-upload" style={{ display: "flex", alignItems: "center", cursor: "pointer" }}>
-                      <IconButton
-                        icon={<AttachmentIcon />}
-                        bg="transparent"
-                        color="black"
-                        aria-label="Upload file"
-                        _hover={{ color: "black" }}
-                        as="label"
-                        htmlFor="file-upload"
-                        mr="-6px"
-                      />
-                      <Text fontSize="sm" color="black">
-                        {formData.attachment ? formData.attachment.name : "Add attachment"}
-                      </Text>
-                    </label>
-                  </Box>
-                  <Input type="file" id="file-upload" display="none" onChange={handleFileChange} />
-                </FormControl>
-                <HStack spacing={5}>
-                  <Button
-                    px="30px"
-                    fontWeight="normal"
-                    rounded="full"
-                    bg="#596435"
-                    color="white"
-                    onClick={handleSubmit}
-                  >
-                    Send
-                  </Button>
-                  <Button
-                    borderWidth="1.5px"
-                    fontWeight="normal"
-                    rounded="full"
-                    variant="outline"
-                    bg="white"
-                    borderColor="#596435"
-                    color="#596435"
-                  >
-                    Cancel
-                  </Button>
-                </HStack>
-              </VStack>
-            </Box>
-          </BrowserView>
-          <MobileView>
-            <Box>
-              <div
-                style={{
-                  position: "absolute",
-                  marginLeft: "20px",
-                  marginTop: "15px",
-                }}
-              >
-                <AlignJustify></AlignJustify>
-              </div>
-              {/* add tree icon */}
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "center",
-                  alignItems: "center",
-                  marginTop: "50px",
-                }}
-              >
-                <Image src="./logo1.png" alt="tree icon" height={"50px"}></Image>
-              </div>
-              <VStack spacing={7} align="start" p="50px" py="50px" width="100%" maxW="900px" mx="auto">
-                <FormControl>
-                  <FormLabel fontWeight="bold">Send to</FormLabel>
-                  <Input
-                    name="recipients"
-                    placeholder="Find recipients"
-                    _placeholder={{ color: "#596435" }}
-                    value={formData.recipients}
-                    onChange={handleChange}
-                    {...InputStyleAnnouncement}
-                  />
-                </FormControl>
-                <FormControl>
-                  <FormLabel fontWeight="bold">Subject</FormLabel>
-                  <Input
-                    name="subject"
-                    placeholder="Subject line here"
-                    _placeholder={{ color: "#596435" }}
-                    value={formData.subject}
-                    onChange={handleChange}
-                    {...InputStyleAnnouncement}
-                  />
-                </FormControl>
-                <FormControl position="relative">
-                  <FormLabel fontWeight="bold">Message</FormLabel>
-                  <Textarea
-                    name="message"
-                    placeholder="Type your message here..."
-                    _placeholder={{ color: "#596435" }}
-                    value={formData.message}
-                    onChange={handleChange}
-                    {...InputStyleAnnouncement}
-                    h="250px"
-                    pr="40px" // Space for icon
-                  />
-                  <Box position="absolute" bottom="15px" left="10px" display="flex" alignItems="center">
-                    <label htmlFor="file-upload" style={{ display: "flex", alignItems: "center", cursor: "pointer" }}>
-                      <IconButton
-                        icon={<AttachmentIcon />}
-                        bg="transparent"
-                        color="black"
-                        aria-label="Upload file"
-                        _hover={{ color: "black" }}
-                        as="label"
-                        htmlFor="file-upload"
-                        mr="-6px"
-                      />
-                      <Text fontSize="sm" color="black">
-                        {formData.attachment ? formData.attachment.name : "Add attachment"}
-                      </Text>
-                    </label>
-                  </Box>
-                  <Input type="file" id="file-upload" display="none" onChange={handleFileChange} />
-                </FormControl>
-                <HStack spacing={5}>
-                  <Button
-                    px="30px"
-                    fontWeight="normal"
-                    rounded="full"
-                    bg="#596435"
-                    color="white"
-                    onClick={handleSubmit}
-                  >
-                    Send
-                  </Button>
-                  <Button
-                    borderWidth="1.5px"
-                    fontWeight="normal"
-                    rounded="full"
-                    variant="outline"
-                    bg="white"
-                    borderColor="#596435"
-                    color="#596435"
-                  >
-                    Cancel
-                  </Button>
-                </HStack>
-              </VStack>
-            </Box>
-          </MobileView>
-        </>
-      ) : (
-        <></>
-      )}
-    </div>
+              Send to All
+            </Button>
+
+            <Button
+              bg={activeGroup === "admin" ? "#e0efc4" : "white"}
+              color="#596435"
+              border={activeGroup === "admin" ? "2px solid #596435" : "1px solid #ccc"}
+              _hover={{ bg: "#e0efc4" }}
+              onClick={() => {
+                const admins = allUsers.filter((u) => u.role?.toLowerCase().trim() === "admin");
+                console.log("Found admins:", admins);
+                setSelectedRecipients(admins.map((u) => u.email));
+                setActiveGroup("admin");
+              }}
+            >
+              Send to Admin
+            </Button>
+          </div>
+
+          {allUsers.length > 0 && (
+            <div className={styles.checkboxContainer}>
+              {allUsers.map((user) => (
+                <Checkbox
+                  key={user.email}
+                  isChecked={selectedRecipients.includes(user.email)}
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    setSelectedRecipients((prev) =>
+                      checked ? [...prev, user.email] : prev.filter((email) => email !== user.email),
+                    );
+                  }}
+                >
+                  {user.name} ({user.email})
+                </Checkbox>
+              ))}
+            </div>
+          )}
+        </FormControl>
+
+        <FormControl>
+          <FormLabel fontWeight="bold">Subject</FormLabel>
+          <Input
+            name="subject"
+            placeholder="Subject line here"
+            _placeholder={{ color: "#596435" }}
+            value={formData.subject}
+            onChange={handleChange}
+            {...InputStyleAnnouncement}
+          />
+        </FormControl>
+        <FormControl position="relative">
+          <FormLabel fontWeight="bold">Message</FormLabel>
+          <Textarea
+            name="message"
+            placeholder="Type your message here..."
+            _placeholder={{ color: "#596435" }}
+            value={formData.message}
+            onChange={handleChange}
+            {...InputStyleAnnouncement}
+            h="250px"
+            pr="40px"
+          />
+          <Box position="absolute" top="35px" right="15px" display="flex" alignItems="center">
+            <label htmlFor="file-upload" style={{ display: "flex", alignItems: "center", cursor: "pointer" }}>
+              <IconButton
+                icon={<AttachmentIcon />}
+                bg="transparent"
+                color="black"
+                aria-label="Upload file"
+                _hover={{ color: "black" }}
+                as="label"
+                htmlFor="file-upload"
+                mr="-6px"
+              />
+              <Text fontSize="sm" color="black">
+                {formData.attachment ? formData.attachment.name : "Add attachment"}
+              </Text>
+            </label>
+          </Box>
+          <Input type="file" id="file-upload" display="none" onChange={handleFileChange} />
+        </FormControl>
+        <HStack spacing={5}>
+          <Button px="30px" fontWeight="normal" rounded="full" bg="#596435" color="white" onClick={handleSubmit}>
+            Send
+          </Button>
+          <Button
+            borderWidth="1.5px"
+            fontWeight="normal"
+            rounded="full"
+            variant="outline"
+            bg="white"
+            borderColor="#596435"
+            color="#596435"
+          >
+            Cancel
+          </Button>
+        </HStack>
+      </VStack>
+    </Box>
   );
 };
 

--- a/src/app/createAnnouncement/page.tsx
+++ b/src/app/createAnnouncement/page.tsx
@@ -132,8 +132,10 @@ const CreateAnnouncement = () => {
         <Box fontSize="3xl" fontWeight="bold">
           New Message
         </Box>
-        <FormControl className={styles.recipientSection}>
-          <FormLabel fontWeight="bold">Send to</FormLabel>
+        <FormControl as="fieldset" className={styles.recipientSection}>
+          <FormLabel as="legend" fontWeight="bold">
+            Send to
+          </FormLabel>
 
           <div className={styles.buttonRow}>
             <Button
@@ -225,7 +227,7 @@ const CreateAnnouncement = () => {
               </Text>
             </label>
           </Box>
-          <Input type="file" id="file-upload" display="none" onChange={handleFileChange} />
+          <Input type="file" id="file-upload" display="none" onChange={handleFileChange} data-testid="file-upload" />
         </FormControl>
         <HStack spacing={5}>
           <Button px="30px" fontWeight="normal" rounded="full" bg="#596435" color="white" onClick={handleSubmit}>

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -239,141 +239,152 @@ function Messages() {
           </BrowserView>
 
           <MobileView>
-            <div>
-              <div style={{ overflowX: "hidden" }}>
-                <div>
-                  <div>
-                    <div
-                      style={{
-                        position: "absolute",
-                        marginLeft: "20px",
-                        marginTop: "15px",
-                      }}
-                    >
-                      <AlignJustify></AlignJustify>
-                    </div>
-                    {/* add tree icon */}
-                    <div
-                      style={{
-                        display: "flex",
-                        justifyContent: "center",
-                        alignItems: "center",
-                        marginTop: "50px",
-                      }}
-                    >
-                      <Image src="./logo1.png" alt="tree icon" height={"50px"}></Image>
-                    </div>
+            <Box padding="16px" overflowX="auto">
+              <Text className={styles.header} textAlign="center">
+                Messages
+              </Text>
+              <Text className={styles.unread} textAlign="center">
+                {unreadCount} unread {unreadCount === 1 ? "announcement" : "announcements"}
+              </Text>
 
-                    <button
-                      className={`${styles.tab} ${activeTab === "inbox" ? styles.activeTab : ""}`}
-                      style={{ marginTop: "20px", marginLeft: "10px" }}
-                      onClick={() => {
-                        setActiveTab("inbox");
-                        setCurrentPage(1);
-                      }}
-                    >
-                      Inbox
-                    </button>
-                    <button
-                      className={`${styles.tab} ${activeTab === "sent" ? styles.activeTab : ""}`}
-                      style={{ marginLeft: "10px" }}
-                      onClick={() => {
-                        setActiveTab("sent");
-                        setCurrentPage(1);
-                      }}
-                    >
-                      Sent
-                    </button>
-                  </div>
-                  {isAdmin && ( // Only show button if admin
-                    <button
-                      className={styles.newMessageButton}
-                      style={{
-                        position: "fixed",
-                        bottom: "20px",
-                        right: "20px",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        zIndex: "9",
-                      }}
-                    >
-                      New Message +
-                    </button>
-                  )}
+              {/* Tabs */}
+              <Flex
+                className={styles.topBar}
+                justify="space-between"
+                align="center"
+                marginBottom="20px"
+                flexWrap="wrap"
+              >
+                <div className={styles.tabContainer}>
+                  <button
+                    className={`${styles.tab} ${activeTab === "inbox" ? styles.activeTab : ""}`}
+                    onClick={() => {
+                      setActiveTab("inbox");
+                      setCurrentPage(1);
+                    }}
+                  >
+                    Inbox
+                  </button>
+                  <button
+                    className={`${styles.tab} ${activeTab === "sent" ? styles.activeTab : ""}`}
+                    onClick={() => {
+                      setActiveTab("sent");
+                      setCurrentPage(1);
+                    }}
+                  >
+                    Sent
+                  </button>
                 </div>
-                {activeTab === "inbox" ? (
-                  <>
-                    <Stack backgroundColor={"white"} marginTop={7} borderRadius={10} padding={5} margin={3}>
-                      {currentMessages.map((msg) => (
-                        <div
-                          key={msg.id}
-                          className={msg.selected ? styles.fadedRow : ""}
-                          onClick={() => toggleSelect(msg.id)}
-                        >
-                          <div className={msg.selected ? styles.fadedText : ""}>
-                            <Flex alignItems={"center"}>
-                              <Avatar name={msg.sender} size="md" bg="#596334" color="white" />
-                              <div style={{ padding: "10px" }}>
-                                <Flex justify="space-between">
-                                  {msg.sender}
-                                  <Text className={msg.selected ? styles.fadedText : ""}>{msg.date}</Text>
-                                </Flex>
-                                <Text
-                                  style={{
-                                    overflow: "hidden",
-                                    whiteSpace: "nowrap",
-                                    textOverflow: "ellipsis",
-                                    maxWidth: "100%",
-                                  }}
-                                  className={msg.selected ? styles.fadedText : ""}
-                                >
-                                  {msg.message}
-                                </Text>
-                              </div>
-                            </Flex>
-                          </div>
-                          <div style={{ marginTop: "5px" }}>
-                            <Divider />
-                          </div>
-                        </div>
-                      ))}
-                    </Stack>
 
-                    {/* Pagination Controls */}
-                    <Box className={styles.pageControls} style={{ marginBottom: "70px" }}>
-                      <Button
-                        className={styles.pageButton}
-                        onClick={() => handlePageChange(currentPage - 1)}
-                        disabled={currentPage === 1}
-                      >
-                        Previous
-                      </Button>
-
-                      {Array.from({ length: totalPages }, (_, index) => (
-                        <Button
-                          key={index + 1}
-                          className={currentPage === index + 1 ? styles.activePage : styles.pageButton}
-                          onClick={() => handlePageChange(index + 1)}
-                        >
-                          {index + 1}
-                        </Button>
-                      ))}
-
-                      <Button
-                        className={styles.pageButton}
-                        onClick={() => handlePageChange(currentPage + 1)}
-                        disabled={currentPage === totalPages}
-                      >
-                        Next
-                      </Button>
-                    </Box>
-                  </>
-                ) : (
-                  <p className={styles.sentMessage}>Sent messages here.</p>
+                {isAdmin && (
+                  <button className={styles.newMessageButton} onClick={() => router.push("/createAnnouncement")}>
+                    New Message +
+                  </button>
                 )}
-              </div>
-            </div>
+              </Flex>
+
+              {activeTab === "inbox" ? (
+                <Box overflowX="auto">
+                  <Table className={styles.table} size="sm">
+                    <Thead className={styles.tableHeader}>
+                      <Tr>
+                        <Th>Select</Th>
+                        <Th>Sender</Th>
+                        <Th>Subject Line</Th>
+                        <Th>Date</Th>
+                        <Th>Actions</Th>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {currentMessages.map((msg) => (
+                        <Tr key={msg._id} className={styles.clickableRow}>
+                          <Td>
+                            <Checkbox isChecked={msg.selected} onChange={() => toggleSelect(msg.id)} />
+                          </Td>
+                          <Td
+                            className={`${msg.selected ? styles.fadedText : ""}`}
+                            onClick={() => setSelectedMessage(msg)}
+                          >
+                            <Flex className={styles.avatarContainer}>
+                              <Avatar name={msg.sender} size="sm" bg="#596334" color="white" />
+                              {msg.from}
+                            </Flex>
+                          </Td>
+                          <Td className={msg.selected ? styles.fadedText : ""}>{msg.subject}</Td>
+                          <Td className={msg.selected ? styles.fadedText : ""}>
+                            {new Date(msg.time).toLocaleDateString()}
+                          </Td>
+                          <Td>
+                            <ChevronRight
+                              onClick={() => {
+                                setOpenMessagePopUp(true);
+                                setMessageProps({
+                                  date: new Date(msg.time).toLocaleDateString(),
+                                  adminName: msg.from,
+                                  messageContent: msg.message,
+                                  messageTitle: msg.subject,
+                                  id: msg._id,
+                                });
+                              }}
+                            />
+                          </Td>
+                        </Tr>
+                      ))}
+                      {/* Fill blank rows if needed */}
+                      {Array.from({ length: 7 - currentMessages.length }).map((_, i) => (
+                        <Tr key={`empty-${i}`} style={{ height: "55px" }}>
+                          <Td colSpan={5}></Td>
+                        </Tr>
+                      ))}
+                    </Tbody>
+                    <Tfoot>
+                      <Tr>
+                        <Td colSpan={5}>
+                          <Box className={styles.pageControls}>
+                            <Button
+                              className={styles.pageButton}
+                              onClick={() => handlePageChange(currentPage - 1)}
+                              disabled={currentPage === 1}
+                            >
+                              Previous
+                            </Button>
+                            {Array.from({ length: totalPages }, (_, index) => (
+                              <Button
+                                key={index + 1}
+                                className={currentPage === index + 1 ? styles.activePage : styles.pageButton}
+                                onClick={() => handlePageChange(index + 1)}
+                              >
+                                {index + 1}
+                              </Button>
+                            ))}
+                            <Button
+                              className={styles.pageButton}
+                              onClick={() => handlePageChange(currentPage + 1)}
+                              disabled={currentPage === totalPages}
+                            >
+                              Next
+                            </Button>
+                          </Box>
+                        </Td>
+                      </Tr>
+                    </Tfoot>
+                  </Table>
+
+                  {/* Message popup */}
+                  {openMessagePopUp && (
+                    <MessagePopUp
+                      date={messageProps.date}
+                      messageTitle={messageProps.messageTitle}
+                      adminName={messageProps.adminName}
+                      messageContent={messageProps.messageContent}
+                      id={messageProps.id}
+                    />
+                  )}
+                </Box>
+              ) : (
+                <Text className={styles.sentMessage}>Sent messages here.</Text>
+              )}
+            </Box>
           </MobileView>
         </>
       ) : (


### PR DESCRIPTION
## Developer: Thomas Le

Closes #101 

Updated the mobile view of the Messages page to match the desktop layout. 

### Modifications

messages.tsx

- refactored <MobileView> section to reuse the same layout logic as <BrowserView>.
- wrapped tab buttons and the "New Message +" button in a shared Flex container to align them horizontally since it was acting weird in the mobileview
- removed mobile-only floating button styles.
- ensured message table, page buttons, and pop-up match desktop behavior.

### Testing Considerations

{list out what you have tested and what the reviewer should verify}
- verify that on mobile viewports, the "Inbox"/"Sent" tabs and "New Message +" button appear in the same row
- confirm that the table layout (Select, Sender, Subject Line, Date, Actions) matches the desktop layout
- check that message selection, pop-up opening, and pagebuttons still work correctly on mobile

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
![image](https://github.com/user-attachments/assets/be1295a8-d952-46ca-a870-40d43c8f2e1d)
